### PR TITLE
Fix IsAlreadyCommittedQueryLog

### DIFF
--- a/database/sql/sql_test.go
+++ b/database/sql/sql_test.go
@@ -340,7 +340,9 @@ func testPrepareContextWithNotShardingTable(ctx context.Context, t *testing.T, d
 				power     int32
 				createdAt time.Time
 			)
-			stmt.QueryRow(1).Scan(&name, &age, &isGod, &point, &power, &createdAt)
+			if err := stmt.QueryRow(1).Scan(&name, &age, &isGod, &point, &power, &createdAt); err != nil {
+				t.Fatal(err)
+			}
 			if name != "alice" {
 				t.Fatal("cannot scan")
 			}
@@ -354,7 +356,9 @@ func testPrepareContextWithNotShardingTable(ctx context.Context, t *testing.T, d
 				power     int32
 				createdAt time.Time
 			)
-			stmt.QueryRowContext(ctx, 1).Scan(&name, &age, &isGod, &point, &power, &createdAt)
+			if err := stmt.QueryRowContext(ctx, 1).Scan(&name, &age, &isGod, &point, &power, &createdAt); err != nil {
+				t.Fatal(err)
+			}
 			if name != "alice" {
 				t.Fatal("cannot scan")
 			}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -402,9 +402,22 @@ func TestIsAlreadyCommittedQueryLogErrorCase(t *testing.T) {
 }
 
 func TestIsAlreadyCommittedDeleteQueryLog(t *testing.T) {
-	testIsAlreadyCommittedQueryLog(t, &sql.QueryLog{
-		Query: "DELETE from user_stages WHERE id = ? AND user_id = ?",
-		Args:  []interface{}{1, 10},
+	t.Run("simple", func(t *testing.T) {
+		testIsAlreadyCommittedQueryLog(t, &sql.QueryLog{
+			Query: "DELETE from user_stages WHERE id = ? AND user_id = ?",
+			Args:  []interface{}{1, 10},
+		})
+	})
+
+	t.Run("included IN", func(t *testing.T) {
+		testIsAlreadyCommittedQueryLog(t, &sql.QueryLog{
+			Query: "DELETE from user_stages WHERE id IN (1,?,?) AND user_id = ?",
+			Args:  []interface{}{2, 3, 10},
+		})
+		testIsAlreadyCommittedQueryLog(t, &sql.QueryLog{
+			Query: "DELETE from user_items WHERE id IN (?,?) AND user_id = 10",
+			Args:  []interface{}{1, 2},
+		})
 	})
 }
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -434,4 +434,8 @@ func TestIsAlreadyCommittedUpdateQueryLog(t *testing.T) {
 		Query: "UPDATE user_stages set name = ?, age = 5 where user_id = ?",
 		Args:  []interface{}{"alice", 10},
 	})
+	testIsAlreadyCommittedQueryLog(t, &sql.QueryLog{
+		Query: "UPDATE user_stages set name = ?, age = 5 where user_id IN (?,?)",
+		Args:  []interface{}{"alice", 5, 10},
+	})
 }


### PR DESCRIPTION
When pass a query that contains an IN condition to `IsAlreadyCommittedQueryLog` , get the following error.
```
panic: interface conversion: sqlparser.Expr is sqlparser.ValTuple, not *sqlparser.SQLVal [recovered]
	panic: interface conversion: sqlparser.Expr is sqlparser.ValTuple, not *sqlparser.SQLVal
````

Make the following changes to fix this.

- The type of the right expression in the Where clause corresponds to the case of `vtparser.ValTuple`
- Add testcase
- Also, add some error handling in the test.