### PR TITLE
Add configuration parameter for skipping auto create database

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -98,6 +98,8 @@ type Config struct {
 	DistributedTransaction bool `yaml:"distributed_transaction"`
 	// map table name and configuration
 	Tables map[string]*TableConfig `yaml:"tables"`
+	// if true skip auto create database
+	SkipAutoSetup bool `yaml:"skip_auto_setup"`
 }
 
 // ShardColumnName column name of unique id for all shards

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -808,6 +808,9 @@ func setupDBFromConfig(config *config.Config) error {
 	if config == nil {
 		return errors.New("cannot setup database connection. config is nil")
 	}
+	if config.SkipAutoSetup {
+		return nil
+	}
 	for tableName, table := range config.Tables {
 		var err error
 		if table.IsShard {


### PR DESCRIPTION
`connection.SetConfig` calls `setupDBFromConfig` and creates database automatically.

In migration phase this function is really useful. But online application I use a strictly restricted database user ( don't have create database or any needless priviledges.

So I propose the function for skip auto create database.

```
default: &default
  adapter: mysql
  encoding: utf8mb4
  username: appuser
  password: ${appuser_password}

skip_auto_setup: ${skip_auto_setup}
```

